### PR TITLE
Fix local_action errors for mac users

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -19,4 +19,5 @@
    - restart ssh
 
 - name: Attempt to remove pub key from local known_hosts
-  local_action: command  ssh-keygen -f "~/.ssh/known_hosts" -R hostname
+  local_action: command  ssh-keygen -f "$HOME/.ssh/known_hosts" -R hostname
+  sudo: no


### PR DESCRIPTION
The command `ssh-keygen -f "~/.ssh/known_hosts" -R hostname` fails on a mac with the error "mkstemp: No such file or directory". Changing the command to `ssh-keygen -f "$HOME/.ssh/known_hosts" -R hostname` works on the mac and should work in other environments as well.

Also, sudo (i.e., `--sudo`) is needed when running the playbook, which causes this `local_action` to fail with a "password required" error. Since this local action does not need sudo, turning off sudo fixes the error.
